### PR TITLE
Add role.awsRoleName & policy.awsPolicyName

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The controller manager has a couple of input options, which you can set as param
 
 ### Role
 
-The Role resource abstracts an AWS IAM Role. 
+The Role resource abstracts an AWS IAM Role.
 
 Setting an `assumeRolePolicy` or an `assumeRolePolicyRef` is **mandatory**.
 Creating a `ServiceAccount` resource is possible via `createServiceAccount`. The created ServiceAccount includes the EKS OIDC support annotation.
@@ -81,6 +81,8 @@ spec:
   createServiceAccount: true
   addIRSAPolicy: true
   maxSessionDuration: 3600
+  // spec.roleName takes precendence over metadata.name
+  roleName: the-role
 ```
 
 Resulting `ServiceAccount`:
@@ -172,7 +174,7 @@ spec:
 
 ### User
 
-The User resource abstracts an AWS IAM User. 
+The User resource abstracts an AWS IAM User.
 
 Setting `createLoginProfile` or an `createProgrammaticAccess` is **optional**.
 Creating a `Secret` resource, containing Console Login Data, is possible via `createLoginProfile`. The created secret includes the username and password.
@@ -230,7 +232,7 @@ type: Opaque
 
 ### Group
 
-The Group resource abstracts an AWS IAM Group. 
+The Group resource abstracts an AWS IAM Group.
 
 Adding IAM Users to the group, is possible via `users`. The referenced users need to be created via this operator.
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ spec:
       conditions:
         "StringEquals":
           "aws:SourceIp": "172.0.0.1"
+  // spec.awsPolicyName takes precendence over metadata.name
+  awsPolicyName: the-policy
 ```
 
 ### PolicyAttachment

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ spec:
   createServiceAccount: true
   addIRSAPolicy: true
   maxSessionDuration: 3600
-  // spec.roleName takes precendence over metadata.name
-  roleName: the-role
+  // spec.awsRoleName takes precendence over metadata.name
+  awsRoleName: the-role
 ```
 
 Resulting `ServiceAccount`:

--- a/api/v1beta1/policy_helpers.go
+++ b/api/v1beta1/policy_helpers.go
@@ -57,3 +57,10 @@ func (p *Policy) Marshal() iam.PolicyDocument {
 
 	return policyDocument
 }
+
+func (p *Policy) PolicyName() string {
+	if p.Spec.AWSPolicyName != "" {
+		return p.Spec.AWSPolicyName
+	}
+	return p.Name
+}

--- a/api/v1beta1/policy_types.go
+++ b/api/v1beta1/policy_types.go
@@ -91,6 +91,11 @@ type PolicySpec struct {
 	//
 	// Description holds the description string for the Role
 	Description string `json:"description,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	//
+	// AWSPolicyName is the name of the policy to create. If not specified, metadata.name will be used
+	AWSPolicyName string `json:"awsPolicyName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/role_helpers.go
+++ b/api/v1beta1/role_helpers.go
@@ -40,3 +40,10 @@ func (r *Role) Marshal() iam.PolicyDocument {
 
 	return policyDocument
 }
+
+func (r *Role) RoleName() string {
+	if r.Spec.RoleName != "" {
+		return r.Spec.RoleName
+	}
+	return r.Name
+}

--- a/api/v1beta1/role_helpers.go
+++ b/api/v1beta1/role_helpers.go
@@ -42,8 +42,8 @@ func (r *Role) Marshal() iam.PolicyDocument {
 }
 
 func (r *Role) RoleName() string {
-	if r.Spec.RoleName != "" {
-		return r.Spec.RoleName
+	if r.Spec.AWSRoleName != "" {
+		return r.Spec.AWSRoleName
 	}
 	return r.Name
 }

--- a/api/v1beta1/role_types.go
+++ b/api/v1beta1/role_types.go
@@ -51,8 +51,8 @@ type RoleSpec struct {
 
 	// +kubebuilder:validation:Optional
 	//
-	// RoleName is the name of the role to create. If not specified, metadata.name will be used
-	RoleName string `json:"roleName,omitempty"`
+	// AWSRoleName is the name of the role to create. If not specified, metadata.name will be used
+	AWSRoleName string `json:"awsRoleName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/role_types.go
+++ b/api/v1beta1/role_types.go
@@ -48,6 +48,11 @@ type RoleSpec struct {
 	//
 	// Description holds the description string for the Role
 	Description string `json:"description,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	//
+	// RoleName is the name of the role to create. If not specified, metadata.name will be used
+	RoleName string `json:"roleName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/aws-iam.redradrat.xyz_policies.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_policies.yaml
@@ -50,6 +50,10 @@ spec:
           spec:
             description: PolicySpec defines the desired state of Policy
             properties:
+              awsPolicyName:
+                description: AWSPolicyName is the name of the policy to create. If
+                  not specified, metadata.name will be used
+                type: string
               description:
                 description: Description holds the description string for the Role
                 type: string

--- a/config/crd/bases/aws-iam.redradrat.xyz_roles.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_roles.yaml
@@ -106,6 +106,10 @@ spec:
                   namespace:
                     type: string
                 type: object
+              awsRoleName:
+                description: AWSRoleName is the name of the role to create. If not
+                  specified, metadata.name will be used
+                type: string
               createServiceAccount:
                 description: CreateServiceAccount triggers the creation of an annotated
                   ServiceAccount for the created role
@@ -119,10 +123,6 @@ spec:
                 format: int64
                 nullable: true
                 type: integer
-              roleName:
-                description: RoleName is the name of the role to create. If not specified,
-                  metadata.name will be used
-                type: string
             type: object
           status:
             properties:

--- a/config/crd/bases/aws-iam.redradrat.xyz_roles.yaml
+++ b/config/crd/bases/aws-iam.redradrat.xyz_roles.yaml
@@ -119,6 +119,10 @@ spec:
                 format: int64
                 nullable: true
                 type: integer
+              roleName:
+                description: RoleName is the name of the role to create. If not specified,
+                  metadata.name will be used
+                type: string
             type: object
           status:
             properties:

--- a/config/samples/aws-iam_v1beta1_policy.yaml
+++ b/config/samples/aws-iam_v1beta1_policy.yaml
@@ -13,3 +13,4 @@ spec:
       conditions:
         "StringEquals":
           "aws:SourceIp": "172.0.0.1"
+  awsPolicyName: aws-policy-name

--- a/config/samples/aws-iam_v1beta1_role.yaml
+++ b/config/samples/aws-iam_v1beta1_role.yaml
@@ -16,3 +16,4 @@ spec:
     name: policy
     namespace: default
   createServiceAccount: true
+  roleName: the-role-name

--- a/config/samples/aws-iam_v1beta1_role.yaml
+++ b/config/samples/aws-iam_v1beta1_role.yaml
@@ -16,4 +16,4 @@ spec:
     name: policy
     namespace: default
   createServiceAccount: true
-  roleName: the-role-name
+  awsRoleName: aws-role-name

--- a/controllers/group_controller.go
+++ b/controllers/group_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -74,7 +74,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// now let's instantiate our PolicyInstance
 	var ins *iam.PolicyInstance
-	policyName := r.ResourcePrefix + policy.Name
+	policyName := r.ResourcePrefix + policy.PolicyName()
 	if policy.Status.ARN != "" {
 		parsedArn, err := aws.ARNify(policy.Status.ARN)
 		if err != nil {

--- a/controllers/policyattachment_controller.go
+++ b/controllers/policyattachment_controller.go
@@ -26,8 +26,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	iamv1beta1 "github.com/redradrat/aws-iam-operator/api/v1beta1"
 	"github.com/redradrat/cloud-objects/aws/iam"
+
+	iamv1beta1 "github.com/redradrat/aws-iam-operator/api/v1beta1"
 )
 
 // PolicyAssignmentReconciler reconciles a PolicyAssignment object

--- a/controllers/role_controller.go
+++ b/controllers/role_controller.go
@@ -214,7 +214,7 @@ func roleCleanup(r *RoleReconciler, ctx context.Context, role iamv1beta1.Role) f
 		}
 		for _, att := range attachments.Items {
 			if att.Spec.TargetReference.Type == iamv1beta1.RoleTargetType {
-				if att.Spec.TargetReference.Name == role.RoleName() && att.Spec.TargetReference.Namespace == role.Namespace {
+				if att.Spec.TargetReference.Name == role.Name && att.Spec.TargetReference.Namespace == role.Namespace {
 					err := fmt.Errorf(fmt.Sprintf("cannot delete Role due to existing PolicyAttachment '%s/%s'", att.Name, att.Namespace))
 					return err
 				}

--- a/controllers/role_controller.go
+++ b/controllers/role_controller.go
@@ -268,7 +268,7 @@ func getPolicyDoc(role *iamv1beta1.Role, oidcProviderARN string, c client.Client
 		resourceWithoutType := strings.SplitAfterN(arn.Resource, "/", 2)[1]
 		conditions := make(map[iamv1beta1.PolicyStatementConditionKey]string)
 		conditions[iamv1beta1.PolicyStatementConditionKey(fmt.Sprintf("%s:aud", resourceWithoutType))] = "sts.amazonaws.com"
-		conditions[iamv1beta1.PolicyStatementConditionKey(fmt.Sprintf("%s:sub", resourceWithoutType))] = fmt.Sprintf("system:serviceaccount:%s:%s", role.Namespace, role.RoleName())
+		conditions[iamv1beta1.PolicyStatementConditionKey(fmt.Sprintf("%s:sub", resourceWithoutType))] = fmt.Sprintf("system:serviceaccount:%s:%s", role.Namespace, role.Name)
 
 		statement = append(statement, iamv1beta1.AssumeRolePolicyStatementEntry{
 			PolicyStatementEntry: iamv1beta1.PolicyStatementEntry{
@@ -293,7 +293,7 @@ func createRoleServiceAccount(role iamv1beta1.Role, ctx context.Context, client 
 	if role.Spec.CreateServiceAccount {
 		sa := v1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      role.RoleName(),
+				Name:      role.Name,
 				Namespace: role.Namespace,
 				Labels:    role.Labels,
 				Annotations: map[string]string{


### PR DESCRIPTION
[CAPE-326](https://jira.xing.hh/browse/CAPE-326)

In order to create ephemeral environments for each PR we need to update some fields for role and policy.

Each time a microservice creates a PR we link the manifest in the PR branch with a new ArgoCD app made ad-hoc for the PR. The issue is that some aws objects have the same name and we need the ability to change those names.

roles and policies are creating the aws objects with the name defined in "metadata.name", and is causing a conflict with the same objects created from the "main" branch.

So, this PR allows to add a value for "role.spec.awsRoleName" and "policy.spec.awsPolicyName" that takes precedence over "metadata.name".

It has backwards compatibility since "awsRoleName" is not required, is only used when is present.

I've been testing this changes and in both cases the aws resource created have the correct name (awsRoleName or awsPolicyName)